### PR TITLE
Support structs as enums target

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ of a type is accounted for somewhere. There is an overlap with the
 [exhaustive]: https://github.com/nishanths/exhaustive
 
 For the sake of this package an `enum` is a named type with multiple
-values which you're operating on as a collection. They could be strings,
-ints, and even complex types like functions or structs.
+values which you're operating on as a collection. Enums supports what Go 
+refers to as basic literals (strings, numbers) and structs.
 
 ## Example
 
@@ -39,6 +39,19 @@ Using enums we can test that we haven't missed out on a new flag:
 ```golang
 func TestAllFlagsCovered(t *testing.T) {
     enumstest.NoDiff(t, "./feature", "feature.Flag", full.AllFlags())
+}
+```
+
+## Using with structs
+
+We need a way to uniquely identify values in a struct, so the identifier 
+will still have to be a basic literal, and this is done with the 
+`enums:"identifier"` tag.
+
+```golang
+type DefaultFlag struct {
+    Name string `enums:"identifier"`
+    IsOn bool
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ints, and even complex types like functions or structs.
 
 For example, I have an enum type for feature flags. For each request
 I call a 3rdparty service to check the state of each flag, so whenever
-a new flag is created it needs to be added to the All function.
+a new flag is created it needs to be added to the `AllFlags` function.
 
 ```golang
 type Flag string

--- a/enum.go
+++ b/enum.go
@@ -1,6 +1,7 @@
 package enums
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"reflect"
@@ -14,9 +15,10 @@ type Collection []Enum
 
 // Enum represents a a match of a type found in the AST for a package
 type Enum struct {
-	Type  string
-	Name  string
-	Value string // all values are represented as strings from the AST
+	Type      string
+	Name      string
+	FieldName string // if the underlying type is a struct this value is the name of the field that is used to distinguish flags
+	Value     string // all values are represented as strings from the AST
 }
 
 // All finds all variables of typ in pkg
@@ -24,7 +26,7 @@ type Enum struct {
 //   typ is a type in the form: pkgname.Type
 // Example: All("./feature", "feature.Flag")
 func All(pkg string, typ string) (Collection, error) {
-	cfg := packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo}
+	cfg := packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName | packages.NeedDeps}
 	pkgs, err := packages.Load(&cfg, pkg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package: %w", err)
@@ -48,25 +50,64 @@ func All(pkg string, typ string) (Collection, error) {
 				continue
 			}
 
+			var fieldName string
 			var val string
 			for _, v := range decl.Values {
 				switch value := v.(type) {
 				case *ast.BasicLit:
 					val = value.Value
+				case *ast.CompositeLit:
+					fieldName, val, err = structValue(value)
+					if err != nil {
+						return nil, err
+					}
 				default:
-					panic(fmt.Sprintf("unknown type: %T", v))
+					// Either a case where it would be hard to distinguish or something not considered so far. Likely the latter.
+					panic(fmt.Sprintf("unknown type, please file a bug report with example code: '%T'", v))
 				}
 			}
 
 			targets = append(targets, Enum{
-				Type:  t.Type().String(),
-				Name:  t.Name(),
-				Value: val,
+				Type:      t.Type().String(),
+				Name:      t.Name(),
+				FieldName: fieldName,
+				Value:     val,
 			})
 		}
 	}
 
 	return targets, nil
+}
+
+func structValue(exp *ast.CompositeLit) (fieldName string, val string, err error) {
+	typ := exp.Type.(*ast.Ident)
+	decl := typ.Obj.Decl.(*ast.TypeSpec)
+	struc := decl.Type.(*ast.StructType)
+
+	for i, f := range struc.Fields.List {
+		if strings.Contains(f.Tag.Value, "`enums:\"identifier\"`") {
+			if len(f.Names) > 1 {
+				// No idea if or how this could happen, so let's ask for help
+				panic(fmt.Errorf("struct identifier field has more than one Names, please file a bug report with example code: %#v", f.Names))
+			}
+			fieldName = f.Names[0].String()
+
+			kv := exp.Elts[i].(*ast.KeyValueExpr)
+			fieldVal, ok := kv.Value.(*ast.BasicLit)
+			if !ok {
+				return "", "", fmt.Errorf("struct identifier value not a basic literal: %s = %#v", fieldName, kv.Value)
+			}
+
+			val = fieldVal.Value
+			break
+		}
+	}
+
+	if val == "" {
+		return "", "", errors.New(`no struct tag with enum:"identifier" found`)
+	}
+
+	return fieldName, val, err
 }
 
 // Diff contains the result of checking the difference between a Collection and a list of values
@@ -122,7 +163,7 @@ func (e Collection) Diff(actual interface{}) Diff {
 	var diff Diff
 	for i := 0; i < acTyp.Len(); i++ {
 		item := acTyp.Index(i)
-		val := fmt.Sprintf("%#v", item.Interface())
+		val := e.valueFrom(item)
 
 		if _, ok := values[val]; ok {
 			delete(values, val)
@@ -139,4 +180,45 @@ func (e Collection) Diff(actual interface{}) Diff {
 	diff.Missing = missing
 
 	return diff
+}
+
+func (e Collection) valueFrom(item reflect.Value) string {
+	var val string
+
+	switch item.Type().Kind() {
+	case reflect.Struct:
+		val = e.fieldValue(item)
+
+		if val == "" {
+			val = fmt.Sprintf("%#v", item.Interface())
+		}
+	default:
+		val = fmt.Sprintf("%#v", item.Interface())
+	}
+
+	return val
+}
+
+func (e Collection) fieldValue(item reflect.Value) string {
+	if len(e) == 0 {
+		panic("Diff: collection is empty")
+	}
+
+	enum := e[0]
+	typ := item.Type()
+
+	if !strings.HasSuffix(enum.Type, typ.String()) {
+		return ""
+	}
+
+	field, ok := typ.FieldByName(enum.FieldName)
+	if !ok {
+		return ""
+	}
+
+	if tag, ok := field.Tag.Lookup("enums"); !ok || tag != "identifier" {
+		return ""
+	}
+
+	return fmt.Sprintf("%#v", item.FieldByName(enum.FieldName).Interface())
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAll(t *testing.T) {
-	t.Run("returns an empty list when no matches found", func(t *testing.T) {
+	t.Run("returns an empty collection when no matches found", func(t *testing.T) {
 		matches, err := enums.All("./testdata/nomatch", "Flag")
 		require.NoError(t, err, "error when scanning testdata/nomatches")
 
@@ -35,7 +35,7 @@ func TestAll(t *testing.T) {
 		)
 	})
 
-	t.Run("returns all matches found on a single line", func(t *testing.T) {
+	t.Run("returns all matches found", func(t *testing.T) {
 		matches, err := enums.All("./testdata/multimatch", "multimatch.Flag")
 		require.NoError(t, err, "error when scanning testdata/multimatch")
 

--- a/example_test.go
+++ b/example_test.go
@@ -29,4 +29,35 @@ func TestIntegration(t *testing.T) {
 			"expected to have indicated a diff",
 		)
 	})
+
+	t.Run("Handles structs as enum type", func(t *testing.T) {
+		fsCollection, err := enums.All("./testdata/full", "full.FlagStruct")
+		require.NoError(t, err)
+
+		t.Run("when all flags are present", func(t *testing.T) {
+			diff := fsCollection.Diff(full.AllFlagStruct())
+			require.Truef(
+				t,
+				diff.Zero(),
+				"expected no differences: %s", diff,
+			)
+		})
+
+		t.Run("when something is missing", func(t *testing.T) {
+			require.Equal(
+				t,
+				enums.Diff{
+					Missing: enums.Collection{
+						enums.Enum{
+							Type:      "github.com/gaqzi/enums/testdata/full.FlagStruct",
+							Name:      "FlagDefaultOn",
+							FieldName: "Name",
+							Value:     `"flag-default-on"`,
+						},
+					},
+				},
+				fsCollection.Diff(full.MissingFlagStruct()),
+			)
+		})
+	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -14,10 +14,11 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("No error when no difference", func(t *testing.T) {
+		diff := collection.Diff(full.AllFlags())
 		require.True(
 			t,
-			collection.Diff(full.AllFlags()).Zero(),
-			"expected no differences",
+			diff.Zero(),
+			"expected no differences: %s", diff,
 		)
 	})
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package enums_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaqzi/enums"
@@ -26,11 +27,11 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Indicates a difference when one is set", func(t *testing.T) {
-		require.False(
-			t,
-			collection.Diff(full.MissingFlags()).Zero(),
-			"expected to have indicated a diff",
-		)
+		// If you need more control over which flags are part of the
+		// lookup you can modify the returned `enums.Diff` object.
+		diff := collection.Diff(full.MissingFlags())
+
+		assert.False(t, diff.Zero(), "expected to have indicated a diff: %s", diff)
 	})
 
 	t.Run("Handles structs as enum type", func(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaqzi/enums"
+	"github.com/gaqzi/enums/enumstest"
 	"github.com/gaqzi/enums/testdata/full"
 )
 
@@ -14,11 +15,13 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("No error when no difference", func(t *testing.T) {
-		diff := collection.Diff(full.AllFlags())
-		require.True(
+		// Using the helper for the most common scenario
+		enumstest.NoDiff(
 			t,
-			diff.Zero(),
-			"expected no differences: %s", diff,
+			"./testdata/full",
+			"full.Flag",
+			full.AllFlags(),
+			"expected no differences",
 		)
 	})
 

--- a/testdata/full/example.go
+++ b/testdata/full/example.go
@@ -15,15 +15,6 @@ func AllFlags() []Flag {
 	}
 }
 
-// ExtraFlags a bit of a contrived example of returning more data than what's expected
-func ExtraFlags() []interface{} {
-	return []interface{}{
-		DeployAllTheThings,
-		DeployOneThing,
-		"m000",
-	}
-}
-
 // MissingFlags returns all flags except one to show what it looks like when you've forgotten to add it
 func MissingFlags() []Flag {
 	return []Flag{DeployAllTheThings}

--- a/testdata/full/example_struct.go
+++ b/testdata/full/example_struct.go
@@ -1,0 +1,18 @@
+package full
+
+type FlagStruct struct {
+	Name      string `enums:"identifier"`
+	DefaultOn bool
+}
+
+var (
+	FlagDefaultOn = FlagStruct{Name: "flag-default-on", DefaultOn: true}
+)
+
+func AllFlagStruct() []FlagStruct {
+	return []FlagStruct{FlagDefaultOn}
+}
+
+func MissingFlagStruct() []FlagStruct {
+	return []FlagStruct{}
+}


### PR DESCRIPTION
Using basic literals (strings, numbers, etc.) is a good start but you may want to have more complex types. The problem with more complex types is that they're… more complex. Luckily, Go's struct tags really helps out here so a custom tag on a basic literal will also work.