### PR TITLE
document the undocument reason to skip a value

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -83,6 +83,7 @@ func All(pkg string, typ string) (Collection, error) {
 				continue
 			}
 
+			// Ignore values that don't match the string of the type we're matching against.
 			if !strings.HasSuffix(t.Type().String(), typ) {
 				continue
 			}

--- a/enum_test.go
+++ b/enum_test.go
@@ -61,6 +61,31 @@ func TestAll(t *testing.T) {
 			"expected to have gotten back a single match",
 		)
 	})
+
+	t.Run("does not match a variable declared in a func for the type", func(t *testing.T) {
+		// Fixes https://github.com/gaqzi/enums/issues/38.
+		matches, err := enums.All("./testdata/falsepositiveinfunc", "Flag")
+		require.NoError(t, err, "error when scanning testdata/falsepositiveinfunc")
+
+		require.Equal(
+			t,
+			enums.Collection{
+				Type: "github.com/gaqzi/enums/testdata/falsepositiveinfunc.Flag",
+				Enums: []enums.Enum{
+					{
+						Name:  "AnotherExample",
+						Value: `"hello-there"`,
+					},
+					{
+						Name:  "DeployAllTheThings",
+						Value: `"deploy-all-the-things"`,
+					},
+				},
+			},
+			matches,
+			"expected to only have found the one declared flag and not a variable of the type declared anywhere else",
+		)
+	})
 }
 
 func TestCollection_Diff(t *testing.T) {

--- a/testdata/falsepositiveinfunc/example.go
+++ b/testdata/falsepositiveinfunc/example.go
@@ -1,0 +1,19 @@
+package falsepositiveinfunc
+
+type Flag string
+
+const (
+	DeployAllTheThings Flag = "deploy-all-the-things"
+)
+
+var AnotherExample Flag = "hello-there"
+
+// SlicedExample should be ignored, because I can't think of a case where this is what I'd like to match when it's declared top-level.
+var SlicedExample = []Flag{"hello", "there"}
+
+// FalsePositive is used to show a case where the flag is picked up as a declaration when it shouldn't be since it's not done at the file level.
+func FalsePositive() []Flag {
+	var myVar []Flag
+
+	return myVar
+}


### PR DESCRIPTION
- **Ignore declarations not at the top level**
  Or, at least, a best approximation based on levels away from the top
  the variable is declared. Not sure this will be a great solution for
  how to work it, but it's something at least. 😅
  
  Fixes #38.
  

- **Document the undocument reason to skip a value**
  