### PR TITLE
set the oldest supported version of go as the current one

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golangci-lint 2.0.2
-golang 1.22.12
+golang 1.23.7

--- a/enum.go
+++ b/enum.go
@@ -83,14 +83,20 @@ func All(pkg string, typ string) (Collection, error) {
 				continue
 			}
 
-			// Ignore values that don't match the string of the type we're matching against.
-			if !strings.HasSuffix(t.Type().String(), typ) {
+			// Ignore types that don't have Obj since they definitely can't be turned into a declaration
+			// TODO: Obj is deprecated and there's a new way of getting at this information, look into this new way
+			if e.Obj == nil {
 				continue
 			}
 
 			// A declaration with a value and not a type declaration
 			decl, ok := e.Obj.Decl.(*ast.ValueSpec)
 			if !ok {
+				continue
+			}
+
+			// Ignore values that don't match the string of the type we're matching against.
+			if !strings.HasSuffix(t.Type().String(), typ) {
 				continue
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gaqzi/enums
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/testdata/falsepositiveinfunc/example.go
+++ b/testdata/falsepositiveinfunc/example.go
@@ -17,3 +17,9 @@ func FalsePositive() []Flag {
 
 	return myVar
 }
+
+type example struct{}
+
+func (e *example) Method() Flag {
+	return "m000"
+}


### PR DESCRIPTION
- **Ignore methods and only allow declarations**
  Covers another case found in life code
  

- **Set the oldest supported version of Go as the current one**
  1.22 is no longer current
  